### PR TITLE
feat: env var substition in config values

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -32,6 +32,7 @@ module.exports = function (dir, options) {
 
   var config = nconf.get();
 
+  // strip prefix from env vars in config
   Object.keys(config).forEach(function (key) {
     if (key.match(snykMatch)) {
       config[key.replace(/^SNYK_/, '')] = config[key];
@@ -39,7 +40,34 @@ module.exports = function (dir, options) {
     }
   });
 
+  substituteEnvVarValues(config);
+
   debug('loading from %s', dir, JSON.stringify(config, '', 2));
 
   return config;
 };
+
+// recursively replace ${VAL} in config values with process.env.VAL
+function substituteEnvVarValues(config) {
+  Object.keys(config).forEach(function (key) {
+    // recurse through nested objects
+    if (typeof config[key] === 'object') {
+      return substituteEnvVarValues(config[key]);
+    }
+
+    // replace /\${.*?}/g in strings with env var if such exists
+    if (typeof config[key] === 'string') {
+      config[key] = config[key].replace(/(\${.*?})/g, function (_, match) {
+        var val = match.slice(2, -1); // ditch the wrappers
+
+        // explode if env var is missing
+        if (process.env[val] === undefined) {
+          throw new Error('Missing env var to substitute ' + val + ' in \'' +
+                          key + ': "' + config[key] + '"\'');
+        }
+
+        return process.env[val];
+      });
+    }
+  });
+}

--- a/test/fixtures/env/config.default.json
+++ b/test/fixtures/env/config.default.json
@@ -1,0 +1,7 @@
+{
+  "regular": 1,
+  "toBeReplaced": "Replace me twice with ${CONFIG_TEST_VALUE} ${CONFIG_TEST_VALUE}",
+  "nested": {
+    "toBeReplaced": "Replace me with ${CONFIG_TEST_VALUE}"
+  }
+}

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -69,3 +69,38 @@ test('arg truthy correctly parsed', function (t) {
 
   t.end();
 });
+
+test('env var substition throws on missing env vars', function (t) {
+  process.env.CONFIG_TEST_VALUE = undefined;
+
+  try {
+    require('../')(__dirname + '/fixtures/env');
+    t.fail('Should have thrown!');
+  } catch (err) {
+    t.ok(err, 'Throws on missing env vars');
+    t.end();
+  }
+});
+
+test('env var substitution', function (t) {
+  var testFixtureValue = 'a fixture value';
+  process.env.CONFIG_TEST_VALUE = testFixtureValue;
+
+  var config = require('../')(__dirname + '/fixtures/env');
+  var sourceData = require('./fixtures/env/config.default.json');
+
+  t.equal(config.regular, sourceData.regular, 'regular key matches');
+
+  var replacedValue =
+    sourceData.nested.toBeReplaced.replace(/\${CONFIG_TEST_VALUE}/g,
+                                           testFixtureValue);
+  t.equal(config.nested.toBeReplaced, replacedValue,
+          'nested substitution works');
+
+  replacedValue = sourceData.toBeReplaced.replace(/\${CONFIG_TEST_VALUE}/g,
+                                                  testFixtureValue);
+  t.equal(config.toBeReplaced, replacedValue,
+          'substitution works');
+
+  t.end();
+});


### PR DESCRIPTION
Support for env var substition in config values. `${VALUE}` strings are replaced with `process.env.VALUE` *iff* env var is set, exception is thrown if a required env var is missing.