### PR TITLE
feat: coerce lowercase booleans in env to booleans

### DIFF
--- a/lib/nconf-truth.js
+++ b/lib/nconf-truth.js
@@ -19,9 +19,9 @@ nconf.Env.prototype.loadEnv = function () {
     }
   }).forEach(function (key) {
     var value = process.env[key];
-    if (value === 'TRUE') {
+    if (value === 'TRUE' || value === 'true') {
       value = true;
-    } else if (value === 'FALSE') {
+    } else if (value === 'FALSE' || value === 'false') {
       value = false;
     }
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -21,7 +21,10 @@ test('env values override', function (t) {
   t.equal(config.foo, '100', 'config matches');
   t.deepEqual(config.bar, { foo: '200' }, 'object matches');
 
-  process.env = {};
+  delete process.env.SNYK_foo;
+  delete process.env.SNYK_bar__foo;
+  delete process.env.PORT;
+
   t.end();
 });
 
@@ -47,15 +50,20 @@ test('can be called without a path', function (t) {
 test('env truthy correctly parsed', function (t) {
   process.env.SNYK_foo = 'TRUE'; // jshint ignore:line
   process.env.SNYK_bar = 'FALSE'; // jshint ignore:line
-  process.env.SNYK_zoo = 'false'; // jshint ignore:line
+  process.env.SNYK_baz = true; // jshint ignore:line
+  process.env.SNYK_zoo = false; // jshint ignore:line
 
   var config = require('../')(__dirname + '/fixtures/one');
 
-  t.equal(config.foo, true, 'truth config matches');
-  t.equal(config.bar, false, 'false config matches');
-  t.equal(config.zoo, 'false', 'strings left as is');
+  t.strictEqual(config.foo, true, 'TRUE becomes boolean true');
+  t.strictEqual(config.bar, false, 'FALSE becomes boolean false');
+  t.strictEqual(config.baz, true, 'true becomes boolean true');
+  t.strictEqual(config.zoo, false, 'false becomes boolean false');
 
-  process.env = {};
+  delete process.env.SNYK_foo;
+  delete process.env.SNYK_bar;
+  delete process.env.SNYK_baz;
+  delete process.env.SNYK_zoo;
 
   t.end();
 });
@@ -71,7 +79,7 @@ test('arg truthy correctly parsed', function (t) {
 });
 
 test('env var substition throws on missing env vars', function (t) {
-  process.env.CONFIG_TEST_VALUE = undefined;
+  delete process.env.CONFIG_TEST_VALUE;
 
   try {
     require('../')(__dirname + '/fixtures/env');


### PR DESCRIPTION
BREAKING CHANGE: the string "true" and "false" in env vars are coerced
to booleans.

Javascript will represent boolean true and false as lowercase strings,
so this ensures that setting `process.env.SNKY_foo` to boolean `true`
before loading config will result in boolean `true` config value for
`foo`.