### PR TITLE
chore: further updates to travis settings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,10 +9,6 @@ node_js:
   - "8"
   - "6"
   - "4"
-before_install:
-  - echo "//registry.npmjs.org/:_authToken=\${NPM_TOKEN}" > .npmrc
-before_script:
-  - npm prune
 after_success:
   - npm run semantic-release
 branches:


### PR DESCRIPTION
- no need for NPM_TOKEN to authenticate with npmjs, all deps are public
- no need to prune deps after installing