### PR TITLE
feat: update deps

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -2,7 +2,6 @@ var debug = require('debug')('snyk:config');
 var nconf = require('nconf');
 require('./nconf-truth');
 var path = require('path');
-var pathIsAbsolute = require('path-is-absolute'); // comes with 0.12.x
 
 module.exports = function (dir, options) {
   if (!dir) {
@@ -13,7 +12,7 @@ module.exports = function (dir, options) {
   var secretConfig = options.secretConfig ||
                      path.resolve(dir, 'config.secret.json');
 
-  if (!pathIsAbsolute(dir)) {
+  if (!path.isAbsolute(dir)) {
     throw new Error('config requires absolute path to read from');
   }
 

--- a/package.json
+++ b/package.json
@@ -17,9 +17,8 @@
     "tape": "^4.0.1"
   },
   "dependencies": {
-    "debug": "^2.2.0",
-    "nconf": "^0.7.2",
-    "path-is-absolute": "^1.0.0"
+    "debug": "^3.1.0",
+    "nconf": "^0.10.0"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Updating dependencies now that nodejs 4 is the minimal expected runtime version across our codebase.