### PR TITLE
feat: option to disable config.local

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,20 @@
+- [ ] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
+- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
+- [ ] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)
+
+### What this does
+
+_Explain why this PR exists_
+
+### Notes for the reviewer
+
+_Instructions on how to run this locally, background context, what to review, questions…_
+
+### More information
+
+- [Jira ticket SC-0000](https://snyksec.atlassian.net/browse/SC-0000)
+- [Link to documentation](https://github.com/Snyk/registry/wiki/)
+
+### Screenshots
+
+_Visuals that may help the reviewer_

--- a/lib/index.js
+++ b/lib/index.js
@@ -27,7 +27,10 @@ module.exports = function (dir, options) {
   });
   nconf.argv();
   nconf.file('secret', { file: path.resolve(secretConfig) });
-  nconf.file('local', { file: path.resolve(dir, 'config.local.json') });
+  // used to disable local config for registry tests
+  if (!options.disableConfigLocal) {
+    nconf.file('local', { file: path.resolve(dir, 'config.local.json') });
+  }
   nconf.file('default', { file: path.resolve(dir, 'config.default.json') });
 
   var config = nconf.get();

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -134,3 +134,15 @@ test('env var substitution', function (t) {
 
   t.end();
 });
+
+test('disable config local', function (t) {
+  var config = require('../')(__dirname + '/fixtures/one', {
+    disableConfigLocal: true,
+  });
+
+  t.false(config.bar,
+    'did not load config.local, loaded only config.default');
+  t.equal(config.foo, 1, 'loaded config.default');
+
+  t.end();
+});


### PR DESCRIPTION
The aim of this is to disable config.local when running tests
on registry.

Developing locally with registry requires you to change your
`config.local.json`.
Changing it can affect the tests being run on registry while
developing.