### PR TITLE
chore: codeowners -> arch

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @snyk/arch


### PR DESCRIPTION
We think this is a "platform" tool, so owned by Arch for now.