### PR TITLE
feat: use forked lodash patched against zipObjectDeep vulnerability

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,7 +1,7 @@
 import * as debugFactory from 'debug';
 import * as nconf from 'nconf';
 import * as path from 'path';
-import * as _ from 'lodash';
+import * as _ from '@snyk/lodash';
 
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 require('./nconf-truth');

--- a/package.json
+++ b/package.json
@@ -30,8 +30,8 @@
     "typescript": "^3.7.2"
   },
   "dependencies": {
+    "@snyk/lodash": "4.17.15-patch",
     "debug": "^4.1.1",
-    "lodash": "^4.17.15",
     "nconf": "^0.10.0"
   },
   "repository": {


### PR DESCRIPTION
Use patched lodash to remove the vulnerability in `zipObjectDeep`