### PR TITLE
feat: trim whitespace in returned values

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -107,7 +107,7 @@ function substituteEnvVarValues(config): void {
         }
 
         return process.env[val];
-      });
+      }).trim();
     }
   });
 }

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -54,6 +54,23 @@ test('env values override', function(t) {
   t.end();
 });
 
+test('env values strings are trimmed', function(t) {
+  process.env.SNYK_whitespace = ' string '; // jshint ignore:line
+  process.env.SNYK_bar__whitespace = ' string '; // jshint ignore:line
+
+  var config = loadConfig(__dirname + '/fixtures/one');
+  t.equal(config.whitespace, 'string', 'whitespace gets stripped');
+  t.deepEqual(
+    config.bar,
+    { whitespace: 'string' },
+    'whitespace gets stripped even in objects',
+  );
+
+  delete process.env.SNYK_whitespace;
+  delete process.env.SNYK_bar__whitespace;
+  t.end();
+});
+
 test('secret config overrides local and default', function(t) {
   var config = loadConfig(__dirname + '/fixtures/three', {
     secretConfig: __dirname + '/fixtures/three/config.secret.json',


### PR DESCRIPTION
Following an issue on Windows where customer tried to set envvar and call a command on a single line:

```
C:/ set SNYK_API=http://snyk.io/api/v1 && "c:\Program Files\Snyk\snyk-win.exe" auth <token>
```

This results in config returning `http://snyk.io/api/v1 ` (including the extra space). They had to remove the space, resulting in command:

```
C:/ set SNYK_API=http://snyk.io/api/v1&&  "c:\Program Files\Snyk…
```

This change removes a possibility to have a trailing whitespace in the envvars we consume. I'm not aware of any legitimate use case for it now.