### PR TITLE
feat: Drop Node 8 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,6 @@ node_js:
   - '14'
   - '12'
   - '10'
-  - '8'
 install:
   - npm install
 script:

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,9 +1,9 @@
 {
   "compilerOptions": {
     "outDir": "./dist",
-    "target": "es2017",
+    "target": "es2018",
     "lib": [
-      "es2017"
+      "es2018"
     ],
     "module": "commonjs",
     "declaration": true,


### PR DESCRIPTION
BREAKING CHANGE: This PR drops support for Node 8. This means we no longer test against it, and the TS compile target moves to ES2018, which is not supported by Node 8.