### PR TITLE
fix: remove debug dependency

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,10 +1,10 @@
-import * as debugFactory from 'debug';
 import * as path from 'path';
 import * as _merge from 'lodash.merge';
 // Use vendored and patched nconf without yargs and with our custom TRUE/FALSE logic in env.ts file
 import nconf from './nconf/nconf';
 
-const debug = debugFactory('snyk:config');
+const util = require('util');
+const debug = util.debuglog('snyk:config');
 
 export type Json =
   | string

--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
   },
   "dependencies": {
     "async": "^3.2.0",
-    "debug": "^4.1.1",
     "lodash.merge": "^4.6.2",
     "minimist": "^1.2.5"
   },


### PR DESCRIPTION
Remove usage of debug dependency and use `util.debuglog` native solution instead.