### PR TITLE
feat: support environment variable array values

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,3 +76,6 @@ $ SNYK_from=cli node app.js
   becomes `foo = "10"`
 * To create a nested object structure from the environment values, use two underscores:
   `SNYK_foo__bar = 10` becomes `foo = { bar: "10" }`
+* By default, environment variable values will not be JSON-parsed.
+  Parsing can be enabled by adding the `parseEnvValues` option, or by setting
+  the `CONFIG_PARSE_ENV_VALUES` environment variable.


### PR DESCRIPTION
## What this does 

Introduces a new optional parameter flag for JSON-parsing environment variable values, by either: 
- Providing the `parseEnvValues` option.
- Providing the `CONFIG_PARSE_ENV_VALUES` environment variable. 

## Context

Following [this post](https://snyk.slack.com/archives/C055UT2F23H/p1706282837620619) on #ask-jedi, it was pointed out the we cannot set array elements into configuration-related environment variables. 
These arrays have no other, more suitable place to be set. Here's why:
- `config.secret.json` - Not applicable for non-secret values.
- `config.<env-name>.json` - Not applicable for deployment group/instance specific configurations. 

The same issue exists with secrets outside Registry's `config.secret.json`. For any independent secret, we try setting an environment variable with the secret value, but these would still not support arrays. 

To mitigate this, we would like to unlock the existing logic for JSON-parsing environment variable configuration values, by creating an optional flag. 

## Notes 

- This change is fully backward compatible. By default, the new flag is not enabled. Unless explicitly enabled, the package fully retains the current behavior.