### PR TITLE
fix: log invalid config on env substitution failure

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -79,7 +79,12 @@ export function loadConfig(
     }
   });
 
-  substituteEnvVarValues(config);
+  try {
+    substituteEnvVarValues(config);
+  } catch (err) {
+    debug('There was an error substituting env var values: %s', err, JSON.stringify(config, null, 2));
+    throw err;
+  }
 
   debug('loading from %s', dir, JSON.stringify(config, null, 2));
 

--- a/test/fixtures/null-in-config/config.default.json
+++ b/test/fixtures/null-in-config/config.default.json
@@ -1,0 +1,8 @@
+{
+  "foo": 1,
+  "bar": null,
+  "nested": {
+    "value": 2,
+    "alsoNull": null
+  }
+}

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -187,6 +187,26 @@ describe('snyk-config', () => {
     expect(() => loadConfig(__dirname + '/fixtures/env')).toThrow();
   });
 
+  describe('when config contains null or undefined during env substitution', () => {
+    it('throws TypeError and rethrows the error', () => {
+      expect(() => loadConfig(__dirname + '/fixtures/null-in-config')).toThrow(
+        'Cannot convert undefined or null to object',
+      );
+    });
+
+    it('rethrows the same error (try-catch does not swallow)', () => {
+      try {
+        loadConfig(__dirname + '/fixtures/null-in-config');
+        throw new Error('loadConfig should have thrown');
+      } catch (err: any) {
+        expect(err).toBeInstanceOf(TypeError);
+        expect(err.message).toBe(
+          'Cannot convert undefined or null to object',
+        );
+      }
+    });
+  });
+
   it('supports substituting config values with environment variables', () => {
     const testFixtureValue = 'a fixture value';
     process.env.CONFIG_TEST_VALUE = testFixtureValue;


### PR DESCRIPTION

### Summary
When bootstrapping an application, `loadConfig` can throw `TypeError: Cannot convert undefined or null to object` if the config contains null or undefined values. The stack trace alone does not show which key(s) are at fault. This change catches the error, logs the full config that was being processed, and rethrows so developers can quickly see which key-value pairs are null/undefined and fix them.

### Problem
During startup, if env substitution fails because the config has null or undefined values (e.g. from merged files or JSON), the only signal is an unhandled `TypeError` at `Object.keys(config)`. There is no way to see which part of the config caused the failure, so developers have to guess or inspect multiple config files to find the offending key-value pair.

### Solution
Wrap the call to `substituteEnvVarValues(config)` in `loadConfig` in a try-catch. On error, log the invalid config (the full object that was being processed) before rethrowing. That log gives developers the exact config state at failure time so they can identify and fix the null/undefined keys.

### Changes
- **lib/index.ts** — Try-catch around `substituteEnvVarValues(config)`; on catch, log the invalid config and the error, then rethrow.
- **test/fixtures/null-in-config/config.default.json** — Fixture with null values to trigger the failure path.
- **test/index.test.ts** — Tests that `loadConfig` throws and rethrows when config contains null/undefined during env substitution.

### How to verify
- `npm test`
- `npm test -- --testNamePattern="when config contains null"`